### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,4 @@ indent_size = 2
 tab_width = 2
 charset = utf-8
 trim_trailing_whitespace = true
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# top-most EditorConfig file
+root = true
+
+# a newline ending every file
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ root = true
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+tab_width = 2
+charset = utf-8
+trim_trailing_whitespace = true


### PR DESCRIPTION
Many text editors remove final newline character.
Adding `.editorconfig` would decrease the case occurrence.